### PR TITLE
Using MongoDB X509 auth

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -302,7 +302,13 @@ app.get("/members", async (req, res) => {
 // });
 
 try {
-  mongoose.connect(process.env.MONGODB_URI as string);
+  mongoose.connect(process.env.MONGODB_URI as string, {
+    dbName: "mobilelist",
+    readPreference: "primaryPreferred",
+    authSource: "$external",
+    authMechanism: "MONGODB-X509",
+    tlsCertificateKeyFile: process.env.keyPath as string
+})
 } catch (error) {
   console.error(error);
 }


### PR DESCRIPTION
Required to use hpsk's locally hosted MongoDB instance